### PR TITLE
fix(ci): switch from yarn to npm for Bridgetown 2.0

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -11,11 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: enable corepack and set yarn version to latest stable
-        run: |
-          corepack enable
-          yarn set version stable
-
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -25,8 +20,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          cache: "yarn"
-      - run: yarn install
+          cache: "npm"
+      - run: npm ci
 
       - name: Build
         env:


### PR DESCRIPTION
Bridgetown 2.0 removed yarn support and uses npm instead. The project already has package-lock.json from the upgrade.

- Remove corepack/yarn setup step
- Change cache from yarn to npm
- Use npm ci instead of yarn install